### PR TITLE
feat(benchmarks): 添加 RestSharp 基准测试支持

### DIFF
--- a/WebApiClientCore.Benchmarks/Requests/Benchmark.cs
+++ b/WebApiClientCore.Benchmarks/Requests/Benchmark.cs
@@ -1,6 +1,7 @@
 ﻿using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 using Refit;
+using RestSharp;
 using System;
 using System.IO;
 using System.Net;
@@ -57,6 +58,30 @@ namespace WebApiClientCore.Benchmarks.Requests
                 .AddHttpMessageHandler(() => new XmlResponseHandler())
                 .ConfigureHttpClient(c => c.BaseAddress = new Uri("http://webapiclient.com/"));
 
+            // 配置 RestSharp JSON 客户端
+            services.AddHttpClient("RestSharpJsonClient")
+                .AddHttpMessageHandler(() => new JsonResponseHandler())
+                .ConfigureHttpClient(c => c.BaseAddress = new Uri("http://webapiclient.com/"));
+
+            // 配置 RestSharp XML 客户端
+            services.AddHttpClient("RestSharpXmlClient")
+                .AddHttpMessageHandler(() => new XmlResponseHandler())
+                .ConfigureHttpClient(c => c.BaseAddress = new Uri("http://webapiclient.com/"));
+
+            // 注册 RestSharp JSON 客户端
+            services.AddTransient<RestSharpJsonClient>(sp =>
+            {
+                var httpClient = sp.GetRequiredService<IHttpClientFactory>().CreateClient("RestSharpJsonClient");
+                return new RestSharpJsonClient(httpClient);
+            });
+
+            // 注册 RestSharp XML 客户端
+            services.AddTransient<RestSharpXmlClient>(sp =>
+            {
+                var httpClient = sp.GetRequiredService<IHttpClientFactory>().CreateClient("RestSharpXmlClient");
+                return new RestSharpXmlClient(httpClient);
+            });
+
             this.ServiceProvider = services.BuildServiceProvider();
 
             // 服务显式加载预热
@@ -64,6 +89,8 @@ namespace WebApiClientCore.Benchmarks.Requests
             this.ServiceProvider.GetService<IWebApiClientCoreXmlApi>();
             this.ServiceProvider.GetService<IRefitJsonApi>();
             this.ServiceProvider.GetService<IRefitXmlApi>();
+            this.ServiceProvider.GetService<RestSharpJsonClient>();
+            this.ServiceProvider.GetService<RestSharpXmlClient>();
         }
 
         private class JsonResponseHandler : DelegatingHandler
@@ -93,6 +120,22 @@ namespace WebApiClientCore.Benchmarks.Requests
                     Content = content
                 };
                 return Task.FromResult(response);
+            }
+        }
+
+        // RestSharp JSON客户端包装类
+        public class RestSharpJsonClient : RestClient
+        {
+            public RestSharpJsonClient(HttpClient httpClient) : base(httpClient)
+            {
+            }
+        }
+
+        // RestSharp XML客户端包装类
+        public class RestSharpXmlClient : RestClient
+        {
+            public RestSharpXmlClient(HttpClient httpClient) : base(httpClient)
+            {
             }
         }
     }

--- a/WebApiClientCore.Benchmarks/Requests/HttpGetBenchmark.cs
+++ b/WebApiClientCore.Benchmarks/Requests/HttpGetBenchmark.cs
@@ -1,5 +1,6 @@
 ﻿using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;
+using RestSharp;
 using System.Threading.Tasks;
 
 namespace WebApiClientCore.Benchmarks.Requests
@@ -20,6 +21,15 @@ namespace WebApiClientCore.Benchmarks.Requests
             using var scope = this.ServiceProvider.CreateScope();
             var benchmarkApi = scope.ServiceProvider.GetRequiredService<IRefitJsonApi>();
             await benchmarkApi.GetAsync(id: "id001");
+        }
+
+        [Benchmark]
+        public async Task RestSharp_GetAsync()
+        {
+            using var scope = this.ServiceProvider.CreateScope();
+            var client = scope.ServiceProvider.GetRequiredService<RestSharpJsonClient>();
+            var request = new RestRequest($"/benchmarks/id001");
+            await client.ExecuteAsync(request);
         }
     }
 }

--- a/WebApiClientCore.Benchmarks/Requests/HttpGetJsonBenchmark.cs
+++ b/WebApiClientCore.Benchmarks/Requests/HttpGetJsonBenchmark.cs
@@ -1,5 +1,6 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;
+using RestSharp;
 using System.Threading.Tasks;
 
 namespace WebApiClientCore.Benchmarks.Requests
@@ -20,6 +21,15 @@ namespace WebApiClientCore.Benchmarks.Requests
             using var scope = this.ServiceProvider.CreateScope();
             var benchmarkApi = scope.ServiceProvider.GetRequiredService<IRefitJsonApi>();
             return await benchmarkApi.GetJsonAsync(id: "id001");
+        }
+
+        [Benchmark]
+        public async Task<User> RestSharp_GetJsonAsync()
+        {
+            using var scope = this.ServiceProvider.CreateScope();
+            var client = scope.ServiceProvider.GetRequiredService<RestSharpJsonClient>();
+            var request = new RestRequest($"/benchmarks/id001");
+            return await client.GetAsync<User>(request);
         }
     }
 }

--- a/WebApiClientCore.Benchmarks/Requests/HttpPostJsonBenchmark.cs
+++ b/WebApiClientCore.Benchmarks/Requests/HttpPostJsonBenchmark.cs
@@ -1,5 +1,6 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;
+using RestSharp;
 using System.Threading.Tasks;
 
 namespace WebApiClientCore.Benchmarks.Requests
@@ -19,8 +20,18 @@ namespace WebApiClientCore.Benchmarks.Requests
         public async Task<User> Refit_PostJsonAsync()
         {
             using var scope = this.ServiceProvider.CreateScope();
-            var benchmarkApi = scope.ServiceProvider.GetRequiredService<IRefitJsonApi>();             
+            var benchmarkApi = scope.ServiceProvider.GetRequiredService<IRefitJsonApi>();              
             return await benchmarkApi.PostJsonAsync(User.Instance);
+        }
+
+        [Benchmark]
+        public async Task<User> RestSharp_PostJsonAsync()
+        {
+            using var scope = this.ServiceProvider.CreateScope();
+            var client = scope.ServiceProvider.GetRequiredService<RestSharpJsonClient>();
+            var request = new RestRequest($"/benchmarks")
+                .AddJsonBody(User.Instance);
+            return await client.PostAsync<User>(request);
         }
     }
 }

--- a/WebApiClientCore.Benchmarks/Requests/HttpPostXmlBenchmark.cs
+++ b/WebApiClientCore.Benchmarks/Requests/HttpPostXmlBenchmark.cs
@@ -1,6 +1,9 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;
+using RestSharp;
+using System.Net.Http;
 using System.Threading.Tasks;
+using System;
 
 namespace WebApiClientCore.Benchmarks.Requests
 {
@@ -20,6 +23,16 @@ namespace WebApiClientCore.Benchmarks.Requests
             using var scope = this.ServiceProvider.CreateScope();
             var benchmarkApi = scope.ServiceProvider.GetRequiredService<IRefitXmlApi>();
             return await benchmarkApi.PostXmlAsync(User.Instance);
+        }
+
+        [Benchmark]
+        public async Task<User> RestSharp_PostXmlAsync()
+        {
+            using var scope = this.ServiceProvider.CreateScope();
+            var client = scope.ServiceProvider.GetRequiredService<RestSharpXmlClient>();
+            var request = new RestRequest($"/benchmarks")
+                .AddXmlBody(User.Instance);
+            return await client.PostAsync<User>(request);
         }
     }
 }

--- a/WebApiClientCore.Benchmarks/Requests/HttpPutFormBenchmark.cs
+++ b/WebApiClientCore.Benchmarks/Requests/HttpPutFormBenchmark.cs
@@ -1,5 +1,6 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;
+using RestSharp;
 using System.Threading.Tasks;
 
 namespace WebApiClientCore.Benchmarks.Requests
@@ -20,6 +21,22 @@ namespace WebApiClientCore.Benchmarks.Requests
             using var scope = this.ServiceProvider.CreateScope();
             var benchmarkApi = scope.ServiceProvider.GetRequiredService<IRefitJsonApi>();
             return await benchmarkApi.PutFormAsync(id: "id001", User.Instance);
+        }
+
+        [Benchmark]
+        public async Task<User> RestSharp_PutFormAsync()
+        {
+            using var scope = this.ServiceProvider.CreateScope();
+            var client = scope.ServiceProvider.GetRequiredService<RestSharpJsonClient>();
+            var request = new RestRequest($"/benchmarks/id001")
+                .AddParameter("id", User.Instance.Id)
+                .AddParameter("name", User.Instance.Name)
+                .AddParameter("bio", User.Instance.Bio)
+                .AddParameter("followers", User.Instance.Followers)
+                .AddParameter("following", User.Instance.Following)
+                .AddParameter("url", User.Instance.Url)
+                .AddHeader("Content-Type", "application/x-www-form-urlencoded");
+            return await client.PutAsync<User>(request);
         }
     }
 }

--- a/WebApiClientCore.Benchmarks/WebApiClientCore.Benchmarks.csproj
+++ b/WebApiClientCore.Benchmarks/WebApiClientCore.Benchmarks.csproj
@@ -16,6 +16,7 @@
 		<PackageReference Include="BenchmarkDotNet" Version="0.15.7" />
 		<PackageReference Include="Refit.HttpClientFactory" Version="8.0.0" />
 		<PackageReference Include="Refit.Xml" Version="8.0.0" />
+		<PackageReference Include="RestSharp" Version="111.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
添加 RestSharp 作为新的 HTTP 客户端基准测试工具
在多个请求类型中实现 RestSharp 的基准测试方法
配置 RestSharp 客户端服务并添加相关包装类